### PR TITLE
#2 Update versions for Scala, sbt, plugin and dependencies to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,18 +2,14 @@ organization := "io.github.marad"
 name := "scalartemis"
 version := "1.0.0"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.13.0"
 
 resolvers += Resolver.jcenterRepo
 
-seq(bintraySettings:_*)
-seq(bintrayPublishSettings:_*)
-
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
-  "org.scalacheck" %% "scalacheck" % "1.12.2" % "test",
-  "org.mockito" % "mockito-core" % "1.10.19" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.8",
+  "org.scalacheck" %% "scalacheck" % "1.14.0",
+  "org.mockito" % "mockito-core" % "3.0.0"
 )
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
-  

--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,9 @@ scalaVersion := "2.13.0"
 resolvers += Resolver.jcenterRepo
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.8",
-  "org.scalacheck" %% "scalacheck" % "1.14.0",
-  "org.mockito" % "mockito-core" % "3.0.0"
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
+  "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
+  "org.mockito" % "mockito-core" % "3.0.0" % "test"
 )
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 1.3.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 logLevel := Level.Warn
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.2.1")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")


### PR DESCRIPTION
This PR resolves the outdated versions discussed in #2. I'm not entirely confident that this is without problems - sbt is now complaining about the following:

`There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.`

I'm not really sure how to resolve this. Worst-case scenario, this is a decent starting point for the version upgrade.